### PR TITLE
fix path to macos lsp

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,13 +1,8 @@
 import * as path from 'path';
-import { workspace, ExtensionContext } from 'vscode';
+import { workspace } from 'vscode';
 import { Trace } from 'vscode-jsonrpc';
 
-import {
-	LanguageClient,
-	LanguageClientOptions,
-	ServerOptions,
-	TransportKind
-} from 'vscode-languageclient/node';
+import { LanguageClient } from 'vscode-languageclient/node';
 
 import os from "os";
 
@@ -27,7 +22,7 @@ export function activate(context) {
 				break;
 			}
 			case "darwin": {
-				executable = path.join(context.extensionPath, "c3-lsp-macos");
+				executable = path.join(context.extensionPath, "c3-lsp-darwin");
 				break;
 			}
 			case "linux": {


### PR DESCRIPTION
Hi! This PR fixes a problem with loading LSP on macOS.

```bash
[Error - 22:22:54] C3LSP client: couldn't create connection to server.
Launching server using command /Users/nikita/.vscode/extensions/tonios2.c3-vscode-0.0.84/c3-lsp-macos failed. Error: spawn /Users/nikita/.vscode/extensions/tonios2.c3-vscode-0.0.84/c3-lsp-macos ENOENT
```