### PR TITLE
 fix config section name

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -7,11 +7,12 @@ import { LanguageClient } from 'vscode-languageclient/node';
 import os from "os";
 
 let client;
-const config = workspace.getConfiguration('c3lspclient.lsp');
+const c3Config = workspace.getConfiguration('c3.lsp');
+const c3LSPClientConfig = workspace.getConfiguration('c3lspclient.lsp');
 
 export function activate(context) {
-	let executable = config.get('path');
-	let enabled = config.get('enable');
+	let executable = c3LSPClientConfig.get('path');
+	let enabled = c3LSPClientConfig.get('enable');
 
 	if (enabled == false) return;
 
@@ -36,17 +37,21 @@ export function activate(context) {
 
 	let args = [];
 	
-	if (config.get('sendCrashReports')) {
+	if (c3Config.get('sendCrashReports')) {
 		args.push('--send-crash-reports');
 	}
 
-    if (config.get('log.path').length > 0) {
-        args.push('--log-path ' + config.get('log.path'));
+    if (c3Config.get('log.path').length > 0) {
+        args.push('--log-path ' + c3Config.get('log.path'));
     }
 
-    if (config.get('c3.version')) {
-        args.push('--lang-version '+ config.get('c3.version'));
+    if (c3Config.get('c3.version')) {
+        args.push('--lang-version '+ c3Config.get('c3.version'));
     }
+
+	if (c3Config.get('debug')) {
+		args.push('--debug');
+	}
 
 	const serverOptions = {
 		run: {

--- a/package.json
+++ b/package.json
@@ -39,12 +39,12 @@
 		"configuration": {
 			"title": "Language Server",
 			"properties": {
-				"c3.lsp.enable": {
+				"c3lspclient.lsp.enable": {
 					"type": "boolean",
 					"default": true,
 					"description": "Enables the language server"
 				},
-				"c3.lsp.path": {
+				"c3lspclient.lsp.path": {
 					"type": "string",
 					"default": "c3-lsp",
 					"markdownDescription": "The path to **c3-lsp** binary"
@@ -59,12 +59,12 @@
 					"default": true,
 					"markdownDescription": "Sends crash reports to server to help fixing bugs."
 				},
-				"c3lspclient.lsp.log.path": {
+				"c3.lsp.log.path": {
 					"type": "string",
 					"default": "",
 					"description": "Saves log to specified file"
 				},
-				"c3lspclient.lsp.c3.version": {
+				"c3.lsp.c3.version": {
 					"type": "string",
 					"default": null,
 					"markdownDescription": "Specify C3 language version. If omited, LSP will use the last version it supports."


### PR DESCRIPTION
If I understand correctly, the configuration that is directly passed to the lsp server is prefixed with `c3` and the client configuration with `c3lspclient`. This PR fixes the configuration loading.