### PR TITLE
safely stop lsp client

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -87,5 +87,8 @@ export function activate(context) {
 }
 
 export function deactivate() {
+	if (!client) {
+		return undefined;
+	}
 	return client.stop();
 }


### PR DESCRIPTION
This PR safely stops the LSP client if it is not defined.

Fixes:
```
2024-08-15 19:43:42.044 [error] An error occurred when deactivating the extension 'tonios2.c3-vscode':
2024-08-15 19:43:42.045 [error] TypeError: Cannot read properties of undefined (reading 'stop')
	at Object.dT (/Users/nikita/.vscode/extensions/tonios2.c3-vscode-0.0.86/dist/extension.js:74:40480)
	at m.eb (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:160:9856)
	at /Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:160:7927
	at Array.map (<anonymous>)
	at m.$ (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:160:7914)
	at m.terminate (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:160:8187)
	at $.terminate (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:164:1513)
	at o (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:177:10633)
	at MessagePortMain.<anonymous> (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:177:6825)
	at MessagePortMain.emit (node:events:519:28)
	at MessagePortMain.emit (node:domain:488:12)
	at MessagePortMain._internalPort.emit (node:electron/js2c/utility_init:2:2285)
```

Steps to reproduce:
1. disable LSP via ```c3lspclient.lsp.enable```
2. restart extension