### PR TITLE
Add support for missing string escape codes

### DIFF
--- a/syntaxes/c3.tmLanguage.json
+++ b/syntaxes/c3.tmLanguage.json
@@ -103,7 +103,7 @@
 			"patterns": [
 				{
 					"name": "constant.character.escape",
-					"match": "\\\\([nrt'\"\\\\]|(x[0-9a-fA-F]{2})|(u\\{[0-9a-fA-F]+\\}))"
+					"match": "\\\\([0abefnrtv'\"\\\\]|(x[0-9a-fA-F]{2})|(u\\{[0-9a-fA-F]+\\}))"
 				},
 				{
 					"name": "invalid.illegal.unrecognized-string-escape",


### PR DESCRIPTION
Here is the list supported by c3 : https://c3-lang.org/references/docs/specification/#backslash-escapes